### PR TITLE
Selection breaks upon model change

### DIFF
--- a/pxr/usdQtEditors/outliner.py
+++ b/pxr/usdQtEditors/outliner.py
@@ -600,8 +600,17 @@ class OutlinerTreeView(ContextMenuMixin, QtWidgets.QTreeView):
         self.setUniformRowHeights(True)
         self.header().setStretchLastSection(True)
 
-        self._dataModel = dataModel
+        self._dataModel = None
         self.setModel(dataModel)
+
+    def setModel(self, model):
+        self._dataModel = model
+
+        oldSelectionModel = self.selectionModel()
+        if oldSelectionModel:
+            oldSelectionModel.deleteLater()
+
+        super(OutlinerTreeView, self).setModel(model)
 
         # This can't be a one-liner because of a PySide refcount bug.
         selectionModel = self.selectionModel()


### PR DESCRIPTION
Hi there,

I'm writing this on behalf of Ana Gomez Alcalde, she found a small issue with the selection model not being updated after setting a model into an existing view (breaking the selection). This PR reimplements `setModel` in `OutlinerTreeView` fixing the issue.

Please let me know what you think,
Cheers!