### PR TITLE
Update Layer Save Behavior in Text Editor

### DIFF
--- a/pxr/usdQtEditors/layerTextEditor.py
+++ b/pxr/usdQtEditors/layerTextEditor.py
@@ -101,6 +101,7 @@ class LayerTextEditor(QtWidgets.QWidget):
             raise RuntimeError('Cannot save layer when readOnly is set')
         try:
             success = self._layer.ImportFromString(self.textArea.toPlainText())
+            self._layer.Save()
         except Tf.ErrorException as e:
             QtWidgets.QMessageBox.warning(self, 'Layer Syntax Error',
                                           'Failed to apply modified layer '


### PR DESCRIPTION
I may be missing something here, I'm not very Qt-savvy, but it seems like the apply button in this dialog would save the contents back to the layer, currently it does not. 