### PR TITLE
Fix compilation with gcc > 4.8

### DIFF
--- a/pxr/usdQt/hierarchyCache.cpp
+++ b/pxr/usdQt/hierarchyCache.cpp
@@ -238,13 +238,13 @@ void UsdQt_HierarchyCache::ResyncSubtrees(const std::vector<SdfPath>& paths) {
 }
 
 void UsdQt_HierarchyCache::DebugFullIndex() {
-    std::cout << "Root: " << _root->GetPrim() << std::endl;
     for (const auto& it : _pathToProxy) {
         std::cout << " [path]: " << it.first
                   << " [prim valid]: " << it.second->GetPrim().IsValid()
                   << " [child count]: " << it.second->_GetChildren().size()
                   << std::endl;
     }
+  std::cout << "Root: " << _root->GetPrim().GetPrimPath() << std::endl;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdQt/primFilterCache.h
+++ b/pxr/usdQt/primFilterCache.h
@@ -26,6 +26,7 @@
 #define USDQT_PRIMFILTERCACHE_H
 
 #include <functional>
+#include <iostream>
 #include <unordered_map>
 
 #include "pxr/pxr.h"


### PR DESCRIPTION
`master` wouldn't compile on CentOS 7.4. This PR fixes that by:
- adding a missing iostream include
- fix a bad type conversion