### PR TITLE
Fix #31: Refactor SdfAbstractDataSpecId to SdfPath as per USD 19.11

### DIFF
--- a/pxr/usdQt/undoStateDelegate.h
+++ b/pxr/usdQt/undoStateDelegate.h
@@ -87,33 +87,33 @@ private:
 
     void _OnSetLayer(const SdfLayerHandle& layer) override;
 
-    void _OnSetField(const SdfAbstractDataSpecId& id, const TfToken& fieldName,
+    void _OnSetField(const SdfPath& path, const TfToken& fieldName,
                      const VtValue& value) override;
-    virtual void _OnSetField(const SdfAbstractDataSpecId& id,
+    virtual void _OnSetField(const SdfPath& path,
                              const TfToken& fieldName,
                              const SdfAbstractDataConstValue& value) override;
-    void _OnSetFieldImpl(const SdfAbstractDataSpecId& id,
+    void _OnSetFieldImpl(const SdfPath& path,
                          const TfToken& fieldName);
 
-    virtual void _OnSetFieldDictValueByKey(const SdfAbstractDataSpecId& id,
+    virtual void _OnSetFieldDictValueByKey(const SdfPath& path,
                                            const TfToken& fieldName,
                                            const TfToken& keyPath,
                                            const VtValue& value) override;
     virtual void _OnSetFieldDictValueByKey(
-        const SdfAbstractDataSpecId& id, const TfToken& fieldName,
+        const SdfPath& path, const TfToken& fieldName,
         const TfToken& keyPath,
         const SdfAbstractDataConstValue& value) override;
-    void _OnSetFieldDictValueByKeyImpl(const SdfAbstractDataSpecId& id,
+    void _OnSetFieldDictValueByKeyImpl(const SdfPath& path,
                                        const TfToken& fieldName,
                                        const TfToken& keyPath);
 
-    virtual void _OnSetTimeSample(const SdfAbstractDataSpecId& id, double time,
+    virtual void _OnSetTimeSample(const SdfPath& path, double time,
                                   const VtValue& value) override;
 
     virtual void _OnSetTimeSample(
-        const SdfAbstractDataSpecId& id, double time,
+        const SdfPath& path, double time,
         const SdfAbstractDataConstValue& value) override;
-    void _OnSetTimeSampleImpl(const SdfAbstractDataSpecId& id, double time);
+    void _OnSetTimeSampleImpl(const SdfPath& path, double time);
 
     virtual void _OnCreateSpec(const SdfPath& path, SdfSpecType specType,
                                bool inert) override;


### PR DESCRIPTION
This refactors `SdfAbstractDataSpecId` and updates the `SdfAbstractData` interface to use `SdfPath` for compiling against USD 19.11. The [USD 19.11 changelog states about this](https://github.com/PixarAnimationStudios/USD/blob/dev/CHANGELOG.md#1911---2019-10-18):

> Removed SdfAbstractDataSpecId and updated the SdfAbstractData interface to use SdfPath in its place. Existing SdfAbstractData subclasses must be updated to match. See this usd-interest post for more details: https://groups.google.com/forum/#!topic/usd-interest/IVmd1t1GKBA

I've tried to refactor the code similar to the example links the Changelog links to. So hopefully everything works as expected.

I was able to compile with this change, but have not _yet_ tested whether the tools still continue to work. I'm opening this PR already to discuss code changes and have others test it too.

Having others test it is especially useful as I've never used `usd-qt` before and the extent of my tests or success of using it might be totally related to other things.