### PR TITLE
Fix outliner editor typo 'Dectivate' to 'Deactivate'

### DIFF
--- a/pxr/usdQtEditors/outliner.py
+++ b/pxr/usdQtEditors/outliner.py
@@ -307,7 +307,7 @@ class ActivatePrims(MenuAction):
 
 
 class DeactivatePrims(MenuAction):
-    defaultText = 'Dectivate'
+    defaultText = 'Deactivate'
 
     def Update(self, action, context):
         action.setEnabled(bool(context.selectedPrims))


### PR DESCRIPTION
### Changes

- This fixes a minor typo of `Dectivate` to `Deactivate` in the default Outliner editor in right click context menu on a Prim.